### PR TITLE
Fix dns record structs to match real output from Domeneshop

### DIFF
--- a/src/endpoints/dns.rs
+++ b/src/endpoints/dns.rs
@@ -118,7 +118,7 @@ pub struct MXRecordData {
     /// The target MX host.    
     pub data: String,
     /// MX record priority, also known as preference. Lower values are usually preferred first, but this is not guaranteed
-    pub priority: i16,
+    pub priority: String,
 }
 
 /// Represents data about a SRV-record
@@ -131,11 +131,11 @@ pub struct SRVRecordData {
     /// The target hostname
     pub data: String,
     /// SRV record priority, also known as preference. Lower values are usually preferred first
-    pub priority: i16,
+    pub priority: String,
     /// SRV record weight. Relevant if multiple records have same preference
-    pub weight: i16,
+    pub weight: String,
     /// SRV record port. The port where the service is found.
-    pub port: i16,
+    pub port: String,
 }
 
 /// Represents data about a TXT-record

--- a/tests/dns.rs
+++ b/tests/dns.rs
@@ -193,7 +193,7 @@ async fn list_dns_deserializes_mx_record_correctly() {
     async fn receive_request(_: Request) -> Result<Response, DomeneshopError> {
         let mut response = Response::new(StatusCode::Ok);
         response.set_body(
-            "[{\"id\": 1, \"host\":\"t\", \"ttl\": 1, \"type\": \"MX\", \"data\": \"a\", \"priority\": 1}]",
+            "[{\"id\": 1, \"host\":\"t\", \"ttl\": 1, \"type\": \"MX\", \"data\": \"a\", \"priority\": \"1\"}]",
         );
         Ok(response)
     }
@@ -217,7 +217,7 @@ async fn list_dns_deserializes_srv_record_correctly() {
     async fn receive_request(_: Request) -> Result<Response, DomeneshopError> {
         let mut response = Response::new(StatusCode::Ok);
         response.set_body(
-            "[{\"id\": 1, \"host\":\"t\", \"ttl\": 1, \"type\": \"SRV\", \"data\": \"a\", \"priority\": 1, \"weight\": 1, \"port\": 1}]",
+            "[{\"id\": 1, \"host\":\"t\", \"ttl\": 1, \"type\": \"SRV\", \"data\": \"a\", \"priority\": \"1\", \"weight\": \"1\", \"port\": \"1\"}]",
         );
         Ok(response)
     }


### PR DESCRIPTION
Domeneshop docs does not match real output from the API.
This PR fixes the structs so they match real output, not documented types.